### PR TITLE
adding payload parameters to types and controllers

### DIFF
--- a/pkg/apis/fortio/v1alpha1/curltest_types.go
+++ b/pkg/apis/fortio/v1alpha1/curltest_types.go
@@ -11,11 +11,15 @@ import (
 
 // CurlTestSpec defines the desired state of CurlTest
 type CurlTestSpec struct {
-	URL           string `json:"url"`
-	WaitForCode   string `json:"waitForCode"` // not implemented yet
-	LookForString string `json:"lookForString"`
-	Method        string `json:"method"`
-	ContentType   string `json:"contentType"`
+	URL              string `json:"url"`
+	WaitForCode      string `json:"waitForCode"` // not implemented yet
+	LookForString    string `json:"lookForString"`
+	Method           string `json:"method"`
+	ContentType      string `json:"contentType"`
+	Payload          string `json:"payload"`
+	PayloadSize      string `json:"payloadSize"`
+	MaxPayloadSizeKB string `json:"maxPayloadSizeKB"`
+	PayloadFile      string `json:"payloadFile"`
 	// parameters for TestRun
 	Action        string `json:"action"`
 	Order         string `json:"order"`

--- a/pkg/apis/fortio/v1alpha1/loadtest_types.go
+++ b/pkg/apis/fortio/v1alpha1/loadtest_types.go
@@ -11,15 +11,19 @@ import (
 
 // LoadTestSpec defines the desired state of LoadTest
 type LoadTestSpec struct {
-	URL         string `json:"url"`
-	Duration    string `json:"duration"`
-	Header      string `json:"header"`
-	User        string `json:"user"`
-	Password    string `json:"password"`
-	QPS         string `json:"qps"`
-	Threads     string `json:"threads"`
-	Method      string `json:"method"`
-	ContentType string `json:"contentType"`
+	URL              string `json:"url"`
+	Duration         string `json:"duration"`
+	Header           string `json:"header"`
+	User             string `json:"user"`
+	Password         string `json:"password"`
+	QPS              string `json:"qps"`
+	Threads          string `json:"threads"`
+	Method           string `json:"method"`
+	ContentType      string `json:"contentType"`
+	Payload          string `json:"payload"`
+	PayloadSize      string `json:"payloadSize"`
+	MaxPayloadSizeKB string `json:"maxPayloadSizeKB"`
+	PayloadFile      string `json:"payloadFile"`
 	// parameters for TestRun
 	Action        string `json:"action"`
 	Order         string `json:"order"`

--- a/pkg/controller/curltest/curltest_controller.go
+++ b/pkg/controller/curltest/curltest_controller.go
@@ -213,6 +213,15 @@ func newJobForCR(cr *fortiov1alpha1.CurlTest) *batchv1.Job {
 	} else if strings.ToLower(cr.Spec.Method) == "post" {
 		command = append(command, "-content-type", "text/html")
 	}
+	if cr.Spec.Payload != "" {
+		command = append(command, "-payload", cr.Spec.Payload)
+	}
+	if cr.Spec.PayloadSize != "" {
+		command = append(command, "-payload-size", cr.Spec.PayloadSize)
+	}
+	if cr.Spec.MaxPayloadSizeKB != "" {
+		command = append(command, "-maxpayloadsizekb", cr.Spec.MaxPayloadSizeKB)
+	}
 	// URL should be the last parameter
 	if cr.Spec.URL != "" {
 		command = append(command, cr.Spec.URL)

--- a/pkg/controller/loadtest/loadtest_controller.go
+++ b/pkg/controller/loadtest/loadtest_controller.go
@@ -250,6 +250,15 @@ func newJobForCR(cr *fortiov1alpha1.LoadTest) *batchv1.Job {
 	if cr.Spec.Threads != "" {
 		command = append(command, "-c", cr.Spec.Threads)
 	}
+	if cr.Spec.Payload != "" {
+		command = append(command, "-payload", cr.Spec.Payload)
+	}
+	if cr.Spec.PayloadSize != "" {
+		command = append(command, "-payload-size", cr.Spec.PayloadSize)
+	}
+	if cr.Spec.MaxPayloadSizeKB != "" {
+		command = append(command, "-maxpayloadsizekb", cr.Spec.MaxPayloadSizeKB)
+	}
 	// URL should be the last parameter
 	if cr.Spec.URL != "" {
 		command = append(command, cr.Spec.URL)

--- a/pkg/controller/testrun/testrun_controller.go
+++ b/pkg/controller/testrun/testrun_controller.go
@@ -269,6 +269,15 @@ func newCurlTestCR(cr *fortiov1alpha1.TestRun, spec map[string]string, order int
 	if _, ok := spec["contentType"]; ok {
 		curlTestSpec.ContentType = spec["contentType"]
 	}
+	if _, ok := spec["payload"]; ok {
+		curlTestSpec.Payload = spec["payload"]
+	}
+	if _, ok := spec["payloadSize"]; ok {
+		curlTestSpec.PayloadSize = spec["payloadSize"]
+	}
+	if _, ok := spec["maxPayloadSizeKB"]; ok {
+		curlTestSpec.MaxPayloadSizeKB = spec["maxPayloadSizeKB"]
+	}
 	return &fortiov1alpha1.CurlTest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      strings.ToLower(cr.TypeMeta.Kind) + "-" + cr.Name + "-" + o + "-" + spec["action"] + "-test",
@@ -311,6 +320,15 @@ func newLoadTestCR(cr *fortiov1alpha1.TestRun, spec map[string]string, order int
 	}
 	if _, ok := spec["contentType"]; ok {
 		loadTestSpec.ContentType = spec["contentType"]
+	}
+	if _, ok := spec["payload"]; ok {
+		loadTestSpec.Payload = spec["payload"]
+	}
+	if _, ok := spec["payloadSize"]; ok {
+		loadTestSpec.PayloadSize = spec["payloadSize"]
+	}
+	if _, ok := spec["maxPayloadSizeKB"]; ok {
+		loadTestSpec.MaxPayloadSizeKB = spec["maxPayloadSizeKB"]
 	}
 	return &fortiov1alpha1.LoadTest{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Added all payload parameters + maxpayloadsizekb as payload-size must be smaller than it.
Payload-file parameter was not added yet, will be added for another issue - [issue#9](https://github.com/verfio/fortio-operator/issues/9).